### PR TITLE
Performance

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -198,6 +198,11 @@ git-tree-sha1 = "10134f2ee0b1978ae7752c41306e131a684e1f06"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 version = "1.0.7"
 
+[[Pipe]]
+git-tree-sha1 = "6842804e7867b115ca9de748a0cf6b364523c16d"
+uuid = "b98c9c47-44ae-5843-9183-064241ee97a0"
+version = "1.3.0"
+
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -3,6 +3,12 @@
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
+[[BenchmarkTools]]
+deps = ["JSON", "Logging", "Printf", "Statistics", "UUIDs"]
+git-tree-sha1 = "9e62e66db34540a0c919d72172cc2f642ac71260"
+uuid = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+version = "0.5.0"
+
 [[CSV]]
 deps = ["CategoricalArrays", "DataFrames", "Dates", "FilePathsBase", "Mmap", "Parsers", "PooledArrays", "Tables", "Unicode", "WeakRefStrings"]
 git-tree-sha1 = "52a8e60c7822f53d57e4403b7f2811e7e1bdd32b"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Johannes Boehm <johannes.boehm@gmail.com>"]
 version = "0.2.0"
 
 [deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DataFramesMeta = "1313f7d8-7da2-5740-9ea0-a2ca25f37964"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Douglass"
 uuid = "2218d074-27e7-5dc7-9146-ee5ed9a71057"
 authors = ["Johannes Boehm <johannes.boehm@gmail.com>"]
-version = "0.2.0"
+version = "0.0.1"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
@@ -9,6 +9,7 @@ Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DataFramesMeta = "1313f7d8-7da2-5740-9ea0-a2ca25f37964"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+Pipe = "b98c9c47-44ae-5843-9183-064241ee97a0"
 RDatasets = "ce6b1742-4840-55fa-b093-852dadbb1d8b"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@
 
 Douglass.jl is a package for manipulating DataFrames in Julia using a syntax that is very similar to Stata.
 
+## Installation
+
+Douglass is not registered. To install, type `]` in the Julia command prompt, followed by
+```
+add https://github.com/jmboehm/Douglass.jl.git
+```
+
 ## Examples
 
 ```julia

--- a/src/Douglass.jl
+++ b/src/Douglass.jl
@@ -33,6 +33,8 @@ module Douglass
     using MacroTools
     using REPL
 
+    import DataFramesMeta: @with, @where
+
     # types
     include("Command.jl")
 

--- a/src/Douglass.jl
+++ b/src/Douglass.jl
@@ -50,6 +50,8 @@ module Douglass
     include("commands/replace.jl")
     include("commands/rename.jl")
     include("commands/egen.jl")
+    include("commands/erep.jl")
+    # include("commands/egen2.jl")
     include("commands/merge.jl")
     include("commands/reshape.jl")
     include("commands/duplicates.jl")

--- a/src/commands/drop.jl
+++ b/src/commands/drop.jl
@@ -84,7 +84,7 @@ end
 #             # check that filter expands to a Vector of Union{Bool, Missing}
 #             Douglass.@assert_filter($t, $filter)
 #             # drop it like it's hot
-#             keepme = @with($t, $filter)
+#             keepme = Douglass.@with($t, $filter)
 #             filter!(r -> !keepme[DataFrames.row(r)] , $t)
 #         end
 #     )
@@ -116,7 +116,7 @@ macro drop_if!(t::Symbol, varlist_by::Vector{Symbol},
             $t[!,$(assigned_var_qn)] = trues(size($t,1))
 
             # this is the function that maps every sub-df into its transformed df
-            my_f = _df -> @with _df begin
+            my_f = _df -> Douglass.@with _df begin
                 # define _N 
                 _N = size(_df, 1)
                 # fill the new variable, row by row
@@ -152,7 +152,7 @@ macro drop_if!(t::Symbol, by::Nothing,
                 sort!($t, $varlist_sort)
             end
 
-            @with $t begin
+            Douglass.@with $t begin
                 keepme = BitArray{1}(trues(size($t,1)))
                 # define _N 
                 _N = size($t, 1)

--- a/src/commands/duplicates.jl
+++ b/src/commands/duplicates.jl
@@ -83,3 +83,15 @@ macro duplicates_drop!(t::Symbol,
         end
     )
 end
+
+
+macro duplicates_assert(t::Symbol,
+    variables::Vector{Symbol})
+
+    esc(
+        quote
+            allunique(Tables.namedtupleiterator($t[!,$variables])) || 
+                error("$variables do not uniquely identify observations in DataFrame.")
+        end
+    )
+end

--- a/src/commands/egen.jl
+++ b/src/commands/egen.jl
@@ -150,7 +150,7 @@ macro generate_byvec!(t::Symbol,
                 # check variable is not present
                 ($(assigned_var_qn) ∉ propertynames($t)) || error("Variable $($(assigned_var_qn)) already present in DataFrame.")
                 # determine the column type from doing the transformation on the DF
-                assigned_var_type = eltype(@with($t,$(transformation)))
+                assigned_var_type = eltype(Douglass.@with($t,$(transformation)))
                 # create the new column
                 $t[!,$(assigned_var_qn)] = missings(assigned_var_type,size($t,1))
                 # do the assignment
@@ -191,10 +191,10 @@ macro transform_byvec2!(t::Symbol,
                 # define _N 
                 _N = size(_df, 1)
                 # construct a vector that tells us whether we should copy over the resulting value into the DF
-                assignme = @with(_df, $filter)
+                assignme = Douglass.@with(_df, $filter)
                 #@show assignme
-                sdf = @where(_df, $filter)
-                result = @with(sdf, Douglass.helper_expand(sdf,$(transformation)) )
+                sdf = Douglass.@where(_df, $filter)
+                result = Douglass.@with(sdf, Douglass.helper_expand(sdf,$(transformation)) )
                 # make sure that assignment array is of same size
                 (length(result) == sum(assignme)) || error("Assignment operation results in a vector of the wrong size.")
                 __n = 1
@@ -231,7 +231,7 @@ macro transform_byvec2!(t::Symbol,
                 # define _N 
                 _N = size(_df, 1)
                 # do the transformation
-                result = @with(_df, Douglass.helper_expand(_df,$(transformation)) )
+                result = Douglass.@with(_df, Douglass.helper_expand(_df,$(transformation)) )
                 # make sure that assignment array is of same size
                 (length(result) == size(_df,1)) || error("Assignment operation results in a vector of the wrong size.")
                 _df[:,$(assigned_var_qn)] = result
@@ -260,9 +260,9 @@ macro transform_byvec2!(t::Symbol,
 
                 _N = size(_df, 1)
                 # construct a vector that tells us whether we should copy over the resulting value into the DF
-                assignme = @with(_df, $filter)
-                sdf = @where(_df, $filter)
-                result = @with(sdf, Douglass.helper_expand(sdf,$(transformation)) )
+                assignme = Douglass.@with(_df, $filter)
+                sdf = Douglass.@where(_df, $filter)
+                result = Douglass.@with(sdf, Douglass.helper_expand(sdf,$(transformation)) )
                 # make sure that assignment array is of same size
                 (length(result) == sum(assignme)) || error("Assignment operation results in a vector of the wrong size.")
                 __n::Int64 = 1
@@ -294,7 +294,7 @@ macro transform_byvec2!(t::Symbol,
                 end
                 _N = size(_df, 1)
                 # construct a vector that tells us whether we should copy over the resulting value into the DF
-                result = @with(_df, Douglass.helper_expand(_df,$(transformation)) )
+                result = Douglass.@with(_df, Douglass.helper_expand(_df,$(transformation)) )
                 # copy over manually
                 # this is slower but preserves the type / makes automatic type conversion
                 for _n = 1:_N
@@ -448,7 +448,7 @@ end
 #                 sort!($t, vcat($varlist_by, $varlist_sort))
 #             end
 #             #determine type of resulting column from the type of the first element
-#             assigned_var_type = eltype(@with($t,$(transformation)))
+#             assigned_var_type = eltype(Douglass.@with($t,$(transformation)))
 #             $t[!,$(assigned_var_qn)] = missings(assigned_var_type,size($t,1))
 
 #             # this is the function that maps every sub-df into its transformed df
@@ -456,10 +456,10 @@ end
 #                 # define _N 
 #                 _N = size(_df, 1)
 #                 # construct a vector that tells us whether we should copy over the resulting value into the DF
-#                 assignme = @with(_df, $filter)
+#                 assignme = Douglass.@with(_df, $filter)
 #                 #@show assignme
-#                 sdf = @where(_df, $filter)
-#                 result = @with(sdf, Douglass.helper_expand(sdf,$(transformation)) )
+#                 sdf = Douglass.@where(_df, $filter)
+#                 result = Douglass.@with(sdf, Douglass.helper_expand(sdf,$(transformation)) )
 #                 # make sure that assignment array is of same size
 #                 (length(result) == sum(assignme)) || error("Assignment operation results in a vector of the wrong size.")
 #                 __n = 1
@@ -520,7 +520,7 @@ end
 #                 # define _N 
 #                 _N = size(_df, 1)
 #                 #_df = @transform($t, $(assigned_var) = $(transformation))
-#                 _df[!,$(assigned_var_qn)] = @with(_df, Douglass.helper_expand(_df,$(transformation)) )
+#                 _df[!,$(assigned_var_qn)] = Douglass.@with(_df, Douglass.helper_expand(_df,$(transformation)) )
 #             end
 #             $t = by($t, $varlist_by, my_f )
 #         end
@@ -575,14 +575,14 @@ end
 
 #             if :fill ∈ args
 #                 # assign to all rows in each group, even if $filter is not true
-#                 out = by($t, $varlist_by, _df -> @with(@where(_df, $filter), Douglass.helper_expand(_df,$(transformation))))
+#                 out = by($t, $varlist_by, _df -> Douglass.@with(Douglass.@where(_df, $filter), Douglass.helper_expand(_df,$(transformation))))
 #                 $t[!,$assigned_var] = out[!,:x1]
 #             else
 #                 # assign only to rows where $filter is true
 #                 $t[!,$(assigned_var)] = missings(Float64, size($t,1))
-#                 assignme = @with($t,$(filter))
-#                 out = by($t, $varlist_by, _df -> @with(@where(_df, $filter), Douglass.helper_expand(_df,$(transformation))))
-#                 @with $t begin
+#                 assignme = Douglass.@with($t,$(filter))
+#                 out = by($t, $varlist_by, _df -> Douglass.@with(Douglass.@where(_df, $filter), Douglass.helper_expand(_df,$(transformation))))
+#                 Douglass.@with $t begin
 #                     for i = 1:size($t,1)
 #                         if assignme[i]
 #                             $(assigned_var)[i] = out[i,^(:x1)]
@@ -605,14 +605,14 @@ end
 
 #             if :fill ∈ args
 #                 # assign to all rows in each group, even if $filter is not true
-#                 out = by($t, $varlist_by, _df -> @with(@where(_df, $filter), Douglass.helper_expand(_df,$(transformation))))
+#                 out = by($t, $varlist_by, _df -> Douglass.@with(Douglass.@where(_df, $filter), Douglass.helper_expand(_df,$(transformation))))
 #                 $t[!,$assigned_var] = out[!,:x1]
 #             else
 #                 # assign only to rows where $filter is true
 #                 $t[!,$(assigned_var)] = missings(Float64, size($t,1))
-#                 assignme = @with($t,$(filter))
-#                 out = by($t, $varlist_by, _df -> @with(@where(_df, $filter), Douglass.helper_expand(_df,$(transformation))))
-#                 @with $t begin
+#                 assignme = Douglass.@with($t,$(filter))
+#                 out = by($t, $varlist_by, _df -> Douglass.@with(Douglass.@where(_df, $filter), Douglass.helper_expand(_df,$(transformation))))
+#                 Douglass.@with $t begin
 #                     for i = 1:size($t,1)
 #                         if assignme[i]
 #                             $(assigned_var)[i] = out[i,^(:x1)]

--- a/src/commands/erep.jl
+++ b/src/commands/erep.jl
@@ -1,31 +1,5 @@
-"""
-Examples:
-```julia
-d"egen :x = mean(:y)"
-d"egen :x = :y .+ :z"
-d"egen :x = :y  if :z .> 1.0 "
-d"bysort mygroup (myindex): egen :x = mean(:y)  if :z .> 1.0 "
-```
-`egen` is faster when combined with type declarations, e.g.
-```julia
-d"bysort mygroup (myindex): egen :x::Float64 = mean(:y)  if :z .> 1.0 "
-```
-If the type of the new column is not declared like that, `egen` will try to infer it by applying the right-hand side of the assignment
-operation to the full DataFrame and taking the type of the resulting column. All columns that result from `egen` support `Missing`s.
 
-As in Stata, `if` conditions restrict the set of rows that are being used for the RHS *and* the set of observations
-that are being assigned to. 
-
-Stata's `egen` is inconsistent on how missing values are handled. Some `egen` commands (like `mean()`) ignore all rows 
-that have missing values for one of the variables used on the right-hand side. Other commands (like `rowtotal()`) 
-by default use all rows. 
-The default behavior of Douglass's `egen` is to ignore all rows that have `missing` entries for 
-one or more variables in the right-hand side expression. That does _not_ include columns used in the `if` statement.
-
-Differences to Stata:
-  - Type declarations are done via `d"egen :x::Float64 = :y .+ :z"`. Types are from Julia, of course (which means we can finally use 64-bit Integers!)
-"""
-macro egenerate(t::Symbol, 
+macro ereplace(t::Symbol, 
     by::Union{Vector{Symbol}, Nothing}, 
     sort::Union{Vector{Symbol}, Nothing}, 
     arguments::Union{Vector{Symbol},Union{Expr, Nothing}}, 
@@ -34,14 +8,14 @@ macro egenerate(t::Symbol,
     options::Union{Dict{String,Any}, Nothing})
     error("""\n
         The syntax is:
-            egenerate <var> = <expression> [if <expression>]
+            ereplace <expression> [if] <expression>
         or 
-            bysort <varlist> (<varlist>): egenerate <var> = <expression> [if <expression>]
+            bysort <varlist> (<varlist>): ereplace <expression> [if] <expression>
     """)
 end
 
-# short form. This is a copy of the above for `gen`.
-macro egen(t::Symbol, 
+# short form. This is a copy of the above for `erep`.
+macro erep(t::Symbol, 
     by::Union{Vector{Symbol}, Nothing}, 
     sort::Union{Vector{Symbol}, Nothing}, 
     arguments::Union{Vector{Symbol},Union{Expr, Nothing}}, 
@@ -50,13 +24,13 @@ macro egen(t::Symbol,
     options::Union{Dict{String,Any}, Nothing})
     return esc(
         quote
-            Douglass.@egenerate($t, $by, $sort, $arguments, $filter, $use, $options)
+            Douglass.@ereplace($t, $by, $sort, $arguments, $filter, $use, $options)
         end
     )
 end
 
-macro egenerate(t::Symbol, 
-    by::Vector{Symbol}, 
+macro ereplace(t::Symbol, 
+    by::Union{Vector{Symbol}, Nothing}, 
     sort::Union{Vector{Symbol}, Nothing}, 
     arguments::Expr, 
     filter::Union{Expr, Nothing}, 
@@ -64,35 +38,13 @@ macro egenerate(t::Symbol,
     options::Union{Dict{String,Any}, Nothing})
     return esc(
         quote
-            Douglass.@generate_byvec!($t, $by, $sort, $arguments, $filter, $options )
-        end
-    )
-end
-# version without `by` but with `if`
-macro egenerate(t::Symbol, 
-    by::Nothing, 
-    sort::Union{Vector{Symbol}, Nothing}, 
-    arguments::Expr, 
-    filter::Union{Expr, Nothing}, 
-    use::Nothing, 
-    options::Union{Dict{String,Any}, Nothing})
-    return esc(
-        quote
-            Douglass.@generate_byvec!($t, $by, $sort, $arguments, $filter, $options )
+            Douglass.@replace_byvec!($t, $by, $sort, $arguments, $filter, $options )
         end
     )
 end
 
-# Stata's behavior:
-#
-#   - `if` restricts both the input and output rows to the ones that satisfy this condition
-#   - `egen` does not by default restrict the input rows to those that are nonmissing for all RHS variables, but for some operations it does. 
-#       It never restricts the set of output rows to the nonmissing ones
-#
-# We follow Stata's behavor on [if], and, by default, restrict the input set to those that are nonmissing for all variables
-
-# this is a new implementation that separates the parsing and variable generation from the parsing
-macro generate_byvec!(t::Symbol, 
+# implementation
+macro replace_byvec!(t::Symbol, 
     varlist_by::Union{Vector{Symbol}, Nothing}, 
     varlist_sort::Union{Vector{Symbol}, Nothing}, 
     arguments::Expr, 
@@ -100,48 +52,38 @@ macro generate_byvec!(t::Symbol,
     options::Union{Dict{String,Any}, Nothing})
     
     # assert that `arguments` is an assignment
-    (arguments.head == :(.=)) && error("`egen` expects a vector-wise assignment operation, e.g. `:x = :y + :z`. Do not broadcast the assignment operator.")
-    (arguments.head == :(=)) || error("`egen` expects an assignment operation, e.g. :x = :y + :z")
+    (arguments.head == :(.=)) && error("`erep` expects a vector-wise assignment operation, e.g. `:x = :y + :z`. Do not broadcast the assignment operator.")
+    (arguments.head == :(=)) || error("`erep` expects an assignment operation, e.g. :x = :y + :z")
 
-    assigned_var_type::Symbol = :Any
+    # construct the QuoteNode
     if isexpr(arguments.args[1])
         # this needs to take the form :x::Type
-        error("Expected a Symbol on the left-hand side of `egen` assignment operation, found Expr.")
-        # ( arguments.args[1].head == Symbol("::") ) || error("Expected data type in assignment operation, e.g. `:x::Float64 = ...`")
-        # (size(arguments.args[1].args,1) == 2 ) || error("Expected data type in assignment operation, e.g. `:x::Float64 = ...`")
+        ( arguments.args[1].head == Symbol("::") ) && error("`ereplace` does not allow explicit type declarations`")
         assigned_var_qn = arguments.args[1].args[1]::QuoteNode
     elseif isa(arguments.args[1], QuoteNode)
         assigned_var_qn = arguments.args[1]::QuoteNode
     end
     
-    # if the RHS of the assignment expression is currently a symbol, make it an Expr
-    #transformation = (typeof(arguments.args[2]) == Symbol) ? Expr(arguments.args[2]) : arguments.args[2]
-    #if !isexpr(arguments.args[2])
-    # transformation::Expr = :( )
+    # make sure transformation is an Expr
     if isexpr(arguments.args[2])
         transformation = arguments.args[2]
     elseif isa(arguments.args[2], QuoteNode)
         transformation = Expr(:call, identity, arguments.args[2])
-    else
+    else 
         transformation = Expr(:call, identity, arguments.args[2])
     end
 
-    # println("transformation is a $(typeof(transformation)) with value $(transformation).")
-    # println("assigned_var_qn is a $(typeof(assigned_var_qn)) with value $(assigned_var_qn).")
-
     return esc(
-        quote 
-            # check variable is not present
-            ($(assigned_var_qn) ∉ propertynames($t)) || error("Variable $($(assigned_var_qn)) already present in DataFrame.")
+        quote
+            # check variable is present
+            ($(assigned_var_qn) ∈ propertynames($t)) || error("Variable $($(assigned_var_qn)) not present in DataFrame.")
             # do the assignment
-            Douglass.@transform_byvec_allobs!($t, $varlist_by, $varlist_sort, $assigned_var_qn, $transformation, $filter)
+            Douglass.@replace_byvec_allobs!($t, $varlist_by, $varlist_sort, $assigned_var_qn, $transformation, $filter)
         end
     )
 end
 
-# vector-wise transformation with `if` condition (`by` and `if`)
-# reference implementation
-macro transform_byvec_allobs!(t::Symbol, 
+macro replace_byvec_allobs!(t::Symbol, 
     varlist_by::Vector{Symbol}, 
     varlist_sort::Union{Vector{Symbol}, Nothing}, 
     assigned_var_qn::QuoteNode, 
@@ -157,20 +99,22 @@ macro transform_byvec_allobs!(t::Symbol,
     replace_QuoteNodes!(transformation_converted, :args, qn_vec)
     # and the same for the filter condition
     replace_QuoteNodes!(filter_converted, :args, qn_vec)
+    # add $assigned_var_qn if not already present
+    idx_assigned_var_qn = 0
+    idx = findfirst(isequal(assigned_var_qn), qn_vec)
+    if !isnothing(idx)
+        # already exists in qn_vec
+        idx_assigned_var_qn = idx
+    else
+        push!(qn_vec, assigned_var_qn)
+        idx_assigned_var_qn = length(qn_vec)
+    end
     # add an index subscript to all arg's: arg[#] -> arg[#][index]
     # so that we can condition on a filter
     push_index!(transformation_converted, :indices, :args)
 
     # a vector of the Symbol's for each QuoteNode
     symbol_vec = [qn_vec[i].value for i=1:length(qn_vec)]
-
-    # DEEBUGGING OUTPUT:
-    # println("transformation_converted is a $(typeof(transformation_converted)) with value $(transformation_converted).")
-    # println("filter_converted is a $(typeof(filter_converted)) with value $(filter_converted).")
-    # println("qn_vec is a $(typeof(qn_vec)) with value $(qn_vec).")
-    # println("first element is a $(typeof(qn_vec[1])) with value $(qn_vec[1]).")
-    # @show qn_vec[1]
-    # dump(transformation_converted)
 
     return esc(
         quote
@@ -184,18 +128,17 @@ macro transform_byvec_allobs!(t::Symbol,
             local function my_f(args...)
                 # indices are the indices of the input columns to be used.
                 indices = BitArray($filter_converted)
-                # the following is a wrapper for a[indices] = $transformation_converted
+                # the following is a wrapper for args[idx_assigned_var_qn][indices] = $transformation_converted
                 # but if $transformation_converted expands into a scalar, it's broadcast
-                return Douglass.assign_helper_gen(indices,$transformation_converted)
+                return Douglass.assign_helper_rep!(args[$idx_assigned_var_qn],indices,$transformation_converted)
             end
             transform!(groupby($t, $varlist_by, sort=false, skipmissing = true ), $(symbol_vec) => my_f => $(assigned_var_qn))        
         end
 
     )
 end
-
 # `by` but no `if`
-macro transform_byvec_allobs!(t::Symbol, 
+macro replace_byvec_allobs!(t::Symbol, 
     varlist_by::Vector{Symbol}, 
     varlist_sort::Union{Vector{Symbol}, Nothing}, 
     assigned_var_qn::QuoteNode, 
@@ -205,6 +148,7 @@ macro transform_byvec_allobs!(t::Symbol,
     # go through the expression tree and pick up QuoteNodes.
     qn_vec = Vector{QuoteNode}()
     transformation_converted = deepcopy(transformation)
+    filter_converted = deepcopy(filter)
     
     # replace all QuoteNode's by args[x]
     replace_QuoteNodes!(transformation_converted, :args, qn_vec)
@@ -224,16 +168,14 @@ macro transform_byvec_allobs!(t::Symbol,
             local function my_f(args...)
                 return $transformation_converted
             end
-
-            transform!(groupby($t, $varlist_by, sort=false, skipmissing = true ), $(symbol_vec) => my_f => $(assigned_var_qn))
+            transform!(groupby($t, $varlist_by, sort=false, skipmissing = true ), $(symbol_vec) => my_f => $(assigned_var_qn))        
         end
 
     )
 end
 
-
 # version without groups but with if
-macro transform_byvec_allobs!(t::Symbol, 
+macro replace_byvec_allobs!(t::Symbol, 
     varlist_by::Nothing, 
     varlist_sort::Union{Vector{Symbol}, Nothing}, 
     assigned_var_qn::QuoteNode, 
@@ -249,19 +191,22 @@ macro transform_byvec_allobs!(t::Symbol,
     replace_QuoteNodes!(transformation_converted, :args, qn_vec)
     # and the same for the filter condition
     replace_QuoteNodes!(filter_converted, :args, qn_vec)
+    # add $assigned_var_qn if not already present
+    idx_assigned_var_qn = 0
+    idx = findfirst(isequal(assigned_var_qn), qn_vec)
+    if !isnothing(idx)
+        # already exists in qn_vec
+        idx_assigned_var_qn = idx
+    else
+        push!(qn_vec, assigned_var_qn)
+        idx_assigned_var_qn = length(qn_vec)
+    end
     # add an index subscript to all arg's: arg[#] -> arg[#][index]
     # so that we can condition on a filter
     push_index!(transformation_converted, :indices, :args)
 
     # a vector of the Symbol's for each QuoteNode
     symbol_vec = [qn_vec[i].value for i=1:length(qn_vec)]
-
-    # println("transformation_converted is a $(typeof(transformation_converted)) with value $(transformation_converted).")
-    # println("filter_converted is a $(typeof(filter_converted)) with value $(filter_converted).")
-    # println("qn_vec is a $(typeof(qn_vec)) with value $(qn_vec).")
-    # println("first element is a $(typeof(qn_vec[1])) with value $(qn_vec[1]).")
-    # @show qn_vec[1]
-    # dump(transformation_converted)
 
     return esc(
         quote
@@ -272,14 +217,14 @@ macro transform_byvec_allobs!(t::Symbol,
                 indices = BitArray($filter_converted)
                 # the following is a wrapper for a[indices] = $transformation_converted
                 # but if $transformation_converted expands into a scalar, it's broadcast
-                return Douglass.assign_helper_gen(indices,$transformation_converted)
+                return Douglass.assign_helper_rep!(args[$idx_assigned_var_qn],indices,$transformation_converted)
             end
             transform!($t, $(symbol_vec) => my_f => $(assigned_var_qn))        
         end
     )
 end
 # version without `by` and `if`
-macro transform_byvec_allobs!(t::Symbol, 
+macro replace_byvec_allobs!(t::Symbol, 
     varlist_by::Nothing, 
     varlist_sort::Union{Vector{Symbol}, Nothing}, 
     assigned_var_qn::QuoteNode, 

--- a/src/commands/generate.jl
+++ b/src/commands/generate.jl
@@ -99,11 +99,11 @@ macro generate_byrow!(t::Symbol, varlist_by::Vector{Symbol}, varlist_sort::Union
                 sort!($t, vcat($varlist_by, $varlist_sort))
             end
             #determine type of resulting column from the type of the first element
-            assigned_var_type = eltype([@with($t,$(transformation)) for _n=1])
+            assigned_var_type = eltype([Douglass.@with($t,$(transformation)) for _n=1])
             $t[!,$(assigned_var_qn)] = missings(assigned_var_type,size($t,1))
 
             # this is the function that maps every sub-df into its transformed df
-            my_f = _df -> @with _df begin
+            my_f = _df -> Douglass.@with _df begin
                 # define _N 
                 _N = size(_df, 1)
                 # fill the new variable, row by row
@@ -167,10 +167,10 @@ macro generate!(t::Symbol,
             end
 
             #determine type of resulting column from the type of the first element
-            assigned_var_type = eltype([@with($t,$(transformation)) for _n=1])
+            assigned_var_type = eltype([Douglass.@with($t,$(transformation)) for _n=1])
             $t[!,$(assigned_var_qn)] = missings(assigned_var_type,size($t,1))
 
-            @with $t begin
+            Douglass.@with $t begin
                 # define _N 
                 _N = size($t, 1)
                 # fill the new variable, row by row
@@ -211,7 +211,7 @@ end
 #             end
             
 #             # this is the function that maps every sub-df into its transformed df
-#             my_f = _df -> @with _df begin
+#             my_f = _df -> Douglass.@with _df begin
 #                 # fill the new variable, row by row
 #                 for i in 1:size(_df,1)
 #                     if ($filter)  # if condition is not satisfied, leave with missing
@@ -235,7 +235,7 @@ end
 #             if $varname ∈ propertynames($t)
 #                 error("Table already has a column with this name.")
 #             end
-#             local x = @with($t, ifelse.($filter, $ex , missing))
+#             local x = Douglass.@with($t, ifelse.($filter, $ex , missing))
 #             # if we have a scalar, broadcast
 #             if size(x,1) == 1
 #                 $t[!,$varname] .= x

--- a/src/commands/keep.jl
+++ b/src/commands/keep.jl
@@ -57,7 +57,7 @@ end
 #             # check that filter expands to a Vector of Union{Bool, Missing}
 #             Douglass.@assert_filter($t, $filter)
 #             # drop it like it's hot
-#             keepme = @with($t, $filter)
+#             keepme = Douglass.@with($t, $filter)
 #             filter!(r -> keepme[DataFrames.row(r)] , $t)
 #         end
 #     )
@@ -89,7 +89,7 @@ macro keep_if!(t::Symbol, varlist_by::Vector{Symbol},
             $t[!,$(assigned_var_qn)] = trues(size($t,1))
 
             # this is the function that maps every sub-df into its transformed df
-            my_f = _df -> @with _df begin
+            my_f = _df -> Douglass.@with _df begin
                 # define _N 
                 _N = size(_df, 1)
                 # fill the new variable, row by row
@@ -126,7 +126,7 @@ macro keep_if!(t::Symbol, by::Nothing,
                 sort!($t, $varlist_sort)
             end
 
-            @with $t begin
+            Douglass.@with $t begin
                 keepme = BitArray{1}(trues(size($t,1)))
                 # define _N 
                 _N = size($t, 1)

--- a/src/commands/replace.jl
+++ b/src/commands/replace.jl
@@ -99,7 +99,7 @@ macro replace_byrow!(t::Symbol, varlist_by::Vector{Symbol}, varlist_sort::Union{
             #$t[!,$(assigned_var)] = missings(assigned_var_type,size($t,1))
 
             # this is the function that maps every sub-df into its transformed df
-            my_f = _df -> @with _df begin
+            my_f = _df -> Douglass.@with _df begin
                 # define _N 
                 _N = size(_df, 1)
                 # fill the new variable, row by row
@@ -113,7 +113,7 @@ macro replace_byrow!(t::Symbol, varlist_by::Vector{Symbol}, varlist_sort::Union{
             # execute, and copy it to another dataframe, 
             # otherwise we get copies of the group variables in there as well
             t2 = combine(my_f, groupby($t,$varlist_by, sort=false, skipmissing = false ))
-            @with $t begin
+            Douglass.@with $t begin
                 for _n = 1:size($t,1)
                     if (isnothing($filter) ? true : $filter)
                         $(assigned_var_qn)[_n] = t2[_n,^($(assigned_var_qn))]
@@ -165,7 +165,7 @@ macro replace_byrow!(t::Symbol,
                 sort!($t, $varlist_sort)
             end
 
-            @with $t begin
+            Douglass.@with $t begin
                 # define _N 
                 _N = size($t, 1)
                 # fill the new variable, row by row

--- a/src/helper.jl
+++ b/src/helper.jl
@@ -62,7 +62,7 @@ end
 macro assert_filter(t::Symbol, filter::Expr)
     esc(
         quote
-            local x = @with($t, $filter)
+            local x = Douglass.@with($t, $filter)
             (typeof(x) <: BitArray{1}) || (typeof(x) <: Vector{Union{Missing,Bool}}) || error("filter is not a valid boolean vector.")
             true
         end

--- a/test/Douglass.jl
+++ b/test/Douglass.jl
@@ -1,3 +1,5 @@
+using Revise
+
 using Douglass
 using RDatasets, Test
 using DataFrames
@@ -136,10 +138,6 @@ select!(df, Not([:x]))
 d"bysort :Species (:SepalLength) : egen :x = 1.0 if :SepalWidth .< 3.4"
 @test all(.!ismissing.(df.x) .| (df.SepalWidth .>= 3.4) )
 select!(df, Not([:x]))
-d"bysort :Species (:SepalLength) : egen :x::Int64 = 1.0 if :SepalWidth .< 3.4"
-@test all(.!ismissing.(df.x) .| (df.SepalWidth .>= 3.4) )
-@test eltype(df.x) == Union{Missing, Int64}
-select!(df, Not([:x]))
 
 # with `by` but not `if`
 
@@ -156,10 +154,6 @@ select!(df, Not([:x]))
 d"bysort :Species (:SepalLength) : egen :x = 1.0 "
 @test all(.!ismissing.(df.x) .| (df.SepalWidth .>= 3.4) )
 select!(df, Not([:x]))
-d"bysort :Species (:SepalLength) : egen :x::Int64 = 1.0 "
-@test all(.!ismissing.(df.x) .| (df.SepalWidth .>= 3.4) )
-@test eltype(df.x) == Union{Missing, Int64}
-select!(df, Not([:x]))
 
 # without `by` but with `if`
 
@@ -175,10 +169,6 @@ d"egen :x = :SepalLength if :SepalWidth .< 3.4"
 select!(df, Not([:x]))
 d"egen :x = 1.0 if :SepalWidth .< 3.4"
 @test all(.!ismissing.(df.x) .| (df.SepalWidth .>= 3.4) )
-select!(df, Not([:x]))
-d"egen :x::Int64 = 1.0 if :SepalWidth .< 3.4"
-@test all(.!ismissing.(df.x) .| (df.SepalWidth .>= 3.4) )
-@test eltype(df.x) == Union{Missing, Int64}
 select!(df, Not([:x]))
 
 # without `by` and without `if`
@@ -198,10 +188,6 @@ select!(df, Not([:x]))
 d"egen :x = 1.0 "
 @test all(.!ismissing.(df.x)  )
 @test df.x[1] ≈ 1.0 atol = 1e-4
-select!(df, Not([:x]))
-d"egen :x::Int64 = 1.0"
-@test all(.!ismissing.(df.x) )
-@test eltype(df.x) == Union{Missing, Int64}
 select!(df, Not([:x]))
 
 # ereplace *************

--- a/test/Douglass.jl
+++ b/test/Douglass.jl
@@ -1,6 +1,5 @@
 using Douglass
 using RDatasets, Test
-using DataFramesMeta 
 using DataFrames
 
 df = dataset("datasets", "iris")

--- a/test/benchmark.jl
+++ b/test/benchmark.jl
@@ -1,10 +1,11 @@
+
 using DataFrames, Random, BenchmarkTools
-using Douglass, DataFramesMeta
+using Douglass
 
 rng = MersenneTwister(12345)
 
 # This is Mathieu Gomez's setup for benchmarking FixedEffectModels
-N = 10_000_000
+N = 1_000_000
 K = 100
 id1 = rand(rng,1:div(N, K), N)
 id2 = rand(rng, 1:K, N)
@@ -13,27 +14,81 @@ x2 =  cos.(id1) +  sin.(id2) + randn(N)
 y= 3 .* x1 .+ 5 .* x2 .+ cos.(id1) .+ cos.(id2).^2 .+ randn(N)
 
 df = DataFrame(id1 = categorical(id1), id2 = categorical(id2), x1 = x1, x2 = x2, y = y)
+allowmissing!(df)
+
+df.x2[rand(rng, 1:10,N) .> 8] .= missing
+sort!(df, [:id2, :id1])
+
 
 set_active_df(:df)
 @time d"gen :z = :x1 + :x2"
 @time d"drop :z"
 
-@time d"gen :z = 0.0"
-@time d"replace :z = :x1 + :x2"
-@time d"drop :z"
+# all times are from my 2013 MacBook Pro:
+# julia> versioninfo()
+# Julia Version 1.4.1
+# Commit 381693d3df* (2020-04-14 17:20 UTC)
+# Platform Info:
+#   OS: macOS (x86_64-apple-darwin18.7.0)
+#   CPU: Intel(R) Core(TM) i5-4258U CPU @ 2.40GHz
+#   WORD_SIZE: 64
+#   LIBM: libopenlibm
+#   LLVM: libLLVM-8.0.1 (ORCJIT, haswell)
+#
+# Stata is StataMP 13.1
 
-@time d"gen :z = 0.0"
-@time d"bysort :id2 (:id1): erep :z = mean(:x1)"
-@time d"drop :z"
+# 0.216s
+@btime begin
+    d"gen :z = :x1 + :x2"
+    d"drop :z"
+end
+# Stata: 0.03s
+
+# 0.185s
+@btime begin
+    d"bysort :id2 (:id1): egen :z = mean(:x1)"
+    d"drop :z"
+end
+# Stata: 0.35s
+
+# 0.920s
+@btime begin
+    d"bysort :id2 (:id1): egen :z = mean(:x1) if :x1 .> 0.0"
+    d"drop :z"
+end
+# Stata: 1.44s
+
+using Statistics
+# 0.926s
+@btime begin
+    d"bysort :id2 (:id1): egen :z = cor(:x1,:x2) if :x1 .> 0.0"
+    d"drop :z"
+end
+# Stata: 5.897s
+
+# RESHAPING:
 
 
-@time reg(df, @formula(y ~ x1 + x2))
-# 0.582029 seconds (852 allocations: 535.311 MiB, 18.28% gc time)
-@time reg(df, @formula(y ~ x1 + x2),  Vcov.cluster(:id2))
-# 0.809652 seconds (1.55 k allocations: 649.821 MiB, 14.40% gc time)
-@time reg(df, @formula(y ~ x1 + x2 + fe(id1)))
-# 1.655732 seconds (1.21 k allocations: 734.353 MiB, 16.88% gc time)
-@time reg(df, @formula(y ~ x1 + x2 + fe(id1)), Vcov.cluster(:id1))
-#  2.113248 seconds (499.66 k allocations: 811.751 MiB, 15.08% gc time)
-@time reg(df, @formula(y ~ x1 + x2 + fe(id1) + fe(id2)))
-# 3.553678 seconds (1.36 k allocations: 1005.101 MiB, 10.55% gc time))
+rng = MersenneTwister(12345)
+
+N = 1_000_000
+K = 100
+id1 = vec(repeat(collect(1:100_000),1,10)' )
+id2 = vec(repeat(collect(1:10),100_000,1))
+x1 = 5 * cos.(id1) + 5 * sin.(id2) + randn(N)
+x2 =  cos.(id1) +  sin.(id2) + randn(N)
+y= 3 .* x1 .+ 5 .* x2 .+ cos.(id1) .+ cos.(id2).^2 .+ randn(N)
+
+df = DataFrame(id1 = categorical(id1), id2 = categorical(id2), x1 = x1, x2 = x2, y = y)
+allowmissing!(df)
+
+sort!(df, [:id2, :id1])
+
+
+d"reshape_wide :x1 :x2 :y, i(:id1) j(:id2)"
+d"reshape_long :x1 :x2 :y, i(:id1) j(:id2)"
+
+
+Douglass.@duplicates_assert(df, [:id1, :id2])
+
+include("src/Douglass.jl")

--- a/test/benchmark.jl
+++ b/test/benchmark.jl
@@ -1,0 +1,39 @@
+using DataFrames, Random, BenchmarkTools
+using Douglass, DataFramesMeta
+
+rng = MersenneTwister(12345)
+
+# This is Mathieu Gomez's setup for benchmarking FixedEffectModels
+N = 10_000_000
+K = 100
+id1 = rand(rng,1:div(N, K), N)
+id2 = rand(rng, 1:K, N)
+x1 = 5 * cos.(id1) + 5 * sin.(id2) + randn(N)
+x2 =  cos.(id1) +  sin.(id2) + randn(N)
+y= 3 .* x1 .+ 5 .* x2 .+ cos.(id1) .+ cos.(id2).^2 .+ randn(N)
+
+df = DataFrame(id1 = categorical(id1), id2 = categorical(id2), x1 = x1, x2 = x2, y = y)
+
+set_active_df(:df)
+@time d"gen :z = :x1 + :x2"
+@time d"drop :z"
+
+@time d"gen :z = 0.0"
+@time d"replace :z = :x1 + :x2"
+@time d"drop :z"
+
+@time d"gen :z = 0.0"
+@time d"bysort :id2 (:id1): erep :z = mean(:x1)"
+@time d"drop :z"
+
+
+@time reg(df, @formula(y ~ x1 + x2))
+# 0.582029 seconds (852 allocations: 535.311 MiB, 18.28% gc time)
+@time reg(df, @formula(y ~ x1 + x2),  Vcov.cluster(:id2))
+# 0.809652 seconds (1.55 k allocations: 649.821 MiB, 14.40% gc time)
+@time reg(df, @formula(y ~ x1 + x2 + fe(id1)))
+# 1.655732 seconds (1.21 k allocations: 734.353 MiB, 16.88% gc time)
+@time reg(df, @formula(y ~ x1 + x2 + fe(id1)), Vcov.cluster(:id1))
+#  2.113248 seconds (499.66 k allocations: 811.751 MiB, 15.08% gc time)
+@time reg(df, @formula(y ~ x1 + x2 + fe(id1) + fe(id2)))
+# 3.553678 seconds (1.36 k allocations: 1005.101 MiB, 10.55% gc time))

--- a/test/scratchpad.jl
+++ b/test/scratchpad.jl
@@ -262,3 +262,221 @@
 
 # d"reshape_long :Sepal :Petal, i(:id) j(:Var)"
 # d"reshape_wide :Sepal :Petal, i(:id) j(:Var)"
+
+# ------ BENCHMARK ---------
+
+# using DataFrames, Random, BenchmarkTools
+# using Douglass
+
+# rng = MersenneTwister(12345)
+
+# # This is Mathieu Gomez's setup for benchmarking FixedEffectModels
+# N = 1_000_000
+# K = 100
+# id1 = rand(rng,1:div(N, K), N)
+# id2 = rand(rng, 1:K, N)
+# x1 = 5 * cos.(id1) + 5 * sin.(id2) + randn(N)
+# x2 =  cos.(id1) +  sin.(id2) + randn(N)
+# y= 3 .* x1 .+ 5 .* x2 .+ cos.(id1) .+ cos.(id2).^2 .+ randn(N)
+
+# df = DataFrame(id1 = categorical(id1), id2 = categorical(id2), x1 = x1, x2 = x2, y = y)
+# allowmissing!(df)
+
+# df.x2[rand(rng, 1:10,N) .> 8] .= missing
+# sort!(df, [:id2, :id1])
+
+
+# set_active_df(:df)
+# @time d"gen :z = :x1 + :x2"
+# @time d"drop :z"
+
+# @btime begin
+#     d"gen :z = :x1 + :x2"
+#     d"drop :z"
+# end
+
+# @btime begin
+#     d"bysort :id2 (:id1): egen :z = mean(:x1)"
+#     d"drop :z"
+# end
+
+# @time begin
+#     d"egen :z = mean(:x1)"
+#     d"drop :z"
+# end
+
+# @time d"gen :z = 0.0"
+# @time d"replace :z = :x1 + :x2"
+# @time d"drop :z"
+
+# @time d"gen :z = 0.0"
+# @time d"bysort :id2 (:id1): egen :z = mean(:x1)"
+# @time d"drop :z"
+
+# @time d"bysort :id2 (:id1): egen :z::Float64 = mean(:x1)"
+# @time d"drop :z"
+
+# @time df2 = combine(x -> mean(x) , groupby(df,[:id2], sort=false, skipmissing = false ))
+
+# @time by(df, [:id1], :, :x1 => mean)
+
+# df[:z] .= 0.0
+
+# @time d"drop :z"
+
+# d"bysort :id2 (:id1): egen :z = mean(:x2) if ismissing(:x2)"
+
+# d"drop :z"
+
+# @time transform!(groupby(df, [:id2], sort=false, skipmissing = true ), :x1 => mean => :z)
+
+# function myfun2(args...)
+#     return cor(args[1],args[2])
+# end
+
+
+# @time transform!(groupby(df, [:id2], sort=false, skipmissing = true ), [:x1,:x2] => cor => :z)
+# @time transform!(groupby(df, [:id2], sort=false, skipmissing = true ), [:x1,:y] => cor => :z)
+
+# @time transform!(groupby(df, [:id2], sort=false, skipmissing = true ), [:x1,:y] => myfun2 => :z)
+
+# using Pipe
+
+# @time @pipe df |> groupby(_, :id2) |> transform!(_, :x2 => mean => :z)
+# d"drop :z"
+
+# @time @pipe df |> filter(:y => x -> x>0.0, _) |> groupby(_, :id2) |> transform!(_, :x1 => mean => :z)
+# d"drop :z"
+
+
+# function m_f(x)
+#     a = x[.!ismissing.(x)]
+#     a = a[a .> 0]
+#     return mean(a)
+# end
+
+# @time transform!(groupby(df, [:id2], sort=false, skipmissing = true ), [:x1,:y] => myfun2 => :z)
+
+# # @time @pipe df |> groupby(_, :id2) |> transform!(_, :x2 => mean => :z))
+
+
+# @time transform!(groupby(df, [:id2], sort=false, skipmissing = true ), :x2 => m_f => :z )
+
+# d"drop :z"
+
+# dump( :( a + cor(:x1, :x2)))
+# dump( :(args[1]))
+# dump( :( args[1][2] ))
+
+# a = [ [1, 2] , [3,4]]
+# a[1][2]
+
+# using MacroTools
+
+# ex = :( cor(:x1, :x2, :x1) )
+# qn_vec = Vector{QuoteNode}()
+# replace_QuoteNodes!(ex, :args, qn_vec)
+
+# ex
+# qn_vec
+
+
+# include("src/Douglass.jl")
+
+# using Revise
+
+# using DataFrames, Random, BenchmarkTools
+# using Douglass
+
+# rng = MersenneTwister(12345)
+
+# # This is Mathieu Gomez's setup for benchmarking FixedEffectModels
+# N = 1_000_000
+# K = 100
+# id1 = rand(rng,1:div(N, K), N)
+# id2 = rand(rng, 1:K, N)
+# x1 = 5 * cos.(id1) + 5 * sin.(id2) + randn(N)
+# x2 =  cos.(id1) +  sin.(id2) + randn(N)
+# y= 3 .* x1 .+ 5 .* x2 .+ cos.(id1) .+ cos.(id2).^2 .+ randn(N)
+
+# df = DataFrame(id1 = categorical(id1), id2 = categorical(id2), x1 = x1, x2 = x2, y = y)
+# allowmissing!(df)
+
+# df.x2[rand(rng, 1:10,N) .> 8] .= missing
+# sort!(df, [:id2, :id1])
+
+
+# set_active_df(:df)
+# @time d"gen :z = :x1 + :x2"
+# @time d"drop :z"
+
+# include("src/Douglass.jl")
+
+# @time begin
+#     d"bysort :id2 (:id1): egen :z = mean(:x2) if .!ismissing.(:x2) "
+#     d"drop :z"
+# end
+
+# @time begin
+#     d"bysort :id2 (:id1): egen :z = mean(:y) "
+#     d"drop :z"
+# end
+
+# @time begin
+#     d"egen :z = mean(:x2) if .!ismissing.(:x2) "
+#     d"drop :z"
+# end
+
+# @time begin
+#     d"egen :z = mean(:y) "
+#     d"drop :z"
+# end
+
+
+# using Statistics
+# @time begin
+#     d"bysort :id2 (:id1): egen2 :z = cor(:x1, :x2) if .!ismissing.(:x2)"
+#     d"drop :z"
+# end
+
+# @time d"bysort :id2 (:id1): egen :z = mean(:x2) if .!ismissing.(:x2) "
+
+# d"bysort :id2 (:id1): egen2 :z = cor(:x1, :x2) if 0+1"
+
+# @time d"bysort :id2 (:id1): egen :z = mean(:x1) if 1+1"
+
+
+# @time begin
+#     d"bysort :id2 (:id1): egen :z = :x1 .+ :x2 if :x1 .> 0.0 "
+#     d"drop :z"
+# end
+
+
+# @time begin
+#     d"bysort :id2 (:id1): egen :z = :x1 .+ :x2 if :x1 .> 0.0 "
+#     d"drop :z"
+# end
+
+# include("src/Douglass.jl")
+# @time begin
+#     d"bysort :id2 (:id1) : erep :y = mean(:x1) if :x1 .> 0.0"
+# end
+
+# @time begin
+#     d"bysort :id2 (:id1) : erep :y = mean(:x1) "
+# end
+
+# @time begin
+#     d"erep :y = mean(:x1) if :x1 .> 0.0"
+# end
+
+# @time begin
+#     d"erep :y = mean(:x1)"
+# end
+
+
+# a = Vector{QuoteNode}()
+# push!(a, QuoteNode(:x1))
+# push!(a, QuoteNode(:y))
+# Symbol.(a)
+# println("$(Symbol.(a))")

--- a/test/scratchpad.jl
+++ b/test/scratchpad.jl
@@ -26,7 +26,7 @@
 
 # a = :(:x = :SepalWidth + :PetalLength)
 
-# @with(df, :SepalWidth[1] + :PetalLength[1] )
+# Douglass.@with(df, :SepalWidth[1] + :PetalLength[1] )
 
 # dump(:(Mymodule.@mymacro) )
 


### PR DESCRIPTION
Many of the macros are generating code that is not type stable, and is therefore horrendously slow. This affects in particular
- `egen`/`erep` (fixed with first commit)
- `generate`/`replace` <-- should use `Tables.namedtupeiterator` and a barrier function
- `reshape`
maybe more?